### PR TITLE
Fix volleyball fill attribute to valid color

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ function initApp() {
                         .attr('cx', 0)
                         .attr('cy', 300)
                         .attr('r', 70)
-                        .attr('fill', 'url(https://e7.pngegg.com/pngimages/32/680/png-clipart-blue-white-and-yellow-volleyball-volleyball-net-mikasa-sports-volleyball-sport-orange-thumbnail.png)');
+                        .attr('fill', '#FFD700');
 
   // Append the name element to the volleyball element
   const nameElement = svg.append('text')


### PR DESCRIPTION
Update the `fill` attribute of the volleyball element in `app.js` to a valid color.

* Change the `fill` attribute value from an external image URL to the color `#FFD700`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dehierro/dehierro.github.io/pull/12?shareId=f423ff17-01ca-4c26-9837-5aae6274b68c).